### PR TITLE
renamed except clause

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -47,9 +47,9 @@ def handle_image_conversion(image_filepath):
     image = None
     try:
         image = Image.open(image_filepath)
-    except Exception as e:
+    except Exception as err:
         print(f"Unable to open image file {image_filepath}.")
-        print(e)
+        print(err)
         return
 
     image_ascii = convert_image_to_ascii(image)


### PR DESCRIPTION
Renamed the exception clause from 'e' to  'err', which improves code readability. This can help users to easily identify the exception clause 'err', which holds the error information. 

Hope this PR will be useful !.