### PR TITLE
Added download option in ztm-logo.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,4 @@ dmypy.json
 .pyre/
 
 #saved images
-saved_image.jpg
+ztm-logo-ascii.png

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask, render_template, request, send_from_directory
 from werkzeug.utils import secure_filename
 
-from community_version import handle_image_conversion, is_supported, ALLOWED_EXTENSIONS
+from community_version import handle_image_conversion, is_supported, ALLOWED_EXTENSIONS, save_as_img
 
 UPLOAD_FOLDER = './webapp/uploads'
 TXT_FOLDER = './webapp'
@@ -48,8 +48,12 @@ def generate():
 
 @app.route('/ztm-logo.html', methods=['GET', 'POST'])
 def show_ztm_logo_ascii_img():
-    image = handle_image_conversion(DEFAULT_IMAGE_PATH, KEY_FOLDER)
-    return render_template('ztm-logo.html', image=image)
+    text_image = handle_image_conversion(DEFAULT_IMAGE_PATH, KEY_FOLDER)
+    #form request
+    if request.method == 'POST':
+        image = save_as_img(text_image, 'ztm-logo-ascii.png')
+
+    return render_template('ztm-logo.html', image=text_image)
 
 
 if __name__ == '__main__':

--- a/templates/ztm-logo.html
+++ b/templates/ztm-logo.html
@@ -31,6 +31,7 @@
           <form action="#" method="POST">
               <div class="mb-3">
                 <button class="btn btn-success" onclick="alert('Image downloaded');">Download Image</button>
+                <p>Saves the image in root directory of the project.</p>
             </div>
           </form>
         </div>


### PR DESCRIPTION
Made a download option that allows the user to get a jpg format of the ASCII art.

### NOTE:
The image will be downloaded in the root directory of the project. (ASCII-ART-2021)

And this image file is added to git ignore files.

### Issue No : #51 

Modules used:
Bootstrap v5