### PR TITLE
Optimized GUI to delete previously selected image paths when entering a new one.

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
         global entry1
         tempdir = filedialog.askopenfilename(parent=root, filetypes=(
             ('png files', '*.png'), ('jpeg files', '*.jpg'), ('all files', '*.*')), title='Please select a file')
+        entry1.delete(0, last=tk.END)
         entry1.insert(tk.END, tempdir)
 
     Label(root, text="Image to ASCII Converter", fg="black",


### PR DESCRIPTION
Inside 'browsePic' function : added 'entry.delete(0, last=tk.END)' before inserting a new selected image path, in order for the GUI to delete previously selected paths so that they dont concatenate with the new one