### PR TITLE
Correct aspect ratio

### DIFF
--- a/community_version.py
+++ b/community_version.py
@@ -145,6 +145,15 @@ def validate_file_path(path):
     return path
 
 
+def validate_key_path(path):
+    logger.debug("Validating the key path")
+    if not os.path.isfile(path):
+        logger.warning(f"Invalid key file. Could not find '{path}'")
+        return "./akey.txt"
+    logger.debug("Successfully validated the key path")
+    return path
+
+
 def is_supported(path: str) -> bool:
     """
     Checks if the given path is for a supported file.
@@ -213,7 +222,7 @@ def main():
     image_file_path = validate_file_extension(args.image)
     image_file_path = validate_file_path(image_file_path)
     logger.info(image_file_path)
-    ascii_key_path = args.key
+    ascii_key_path = validate_key_path(args.key)
     logger.info(ascii_key_path)
     width = args.width
     logger.info(f'width={width}px')


### PR DESCRIPTION
This change corrects the aspect ratio of the ascii so that it is the same as the original image.

- modify scale_image with aspect ratio 0.542 (System Font)
- increase default width to 150 to compensate for lost pixels (width 100 now looks a bit small)
- option to specify width in community_version.py (also in handle_image_conversion for use by app.py/gui.py - just add eg 'width=100' to the end of the args

example image:
![house](https://user-images.githubusercontent.com/87418591/139403309-c3db2254-81c5-4610-a124-26583b681b8f.jpg)
ascii without aspect correction:
<img width="553" alt="before" src="https://user-images.githubusercontent.com/87418591/139403320-ccd300f4-636c-4063-a76a-7826a19d8290.png">
ascii with aspect correction:
<img width="816" alt="after" src="https://user-images.githubusercontent.com/87418591/139403328-432ef781-938c-473e-bcba-dcdd61a68b35.png">

)