### PR TITLE
webapp - display ascii as png

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,18 +18,15 @@ if not os.path.exists(config['UPLOAD_FOLDER']):
     os.makedirs(config['UPLOAD_FOLDER'])
 
 
-def convert_image(path):
-    ascii_image = handle_image_conversion(path, config['KEY_FOLDER'])
+def convert_image(infile):
+    ascii_image = handle_image_conversion(infile, config['KEY_FOLDER'])
     with open(config['TXT_FOLDER'] + '/temp.txt', 'w') as f:
         f.write(ascii_image)
-    print(ascii_image)
-    path = config['ASCII_IMAGE_FOLDER'] + '/temp.png'
-    if os.path.exists(path):
-        os.remove(path)
-        save_as_img(ascii_image, config['ASCII_IMAGE_FOLDER'] + '/temp.png')
-    else:
-        save_as_img(ascii_image, config['ASCII_IMAGE_FOLDER'] + '/temp.png')
-    return ascii_image
+    outfile = config['ASCII_IMAGE_FOLDER'] + '/temp.png'
+    if os.path.exists(outfile):
+        os.remove(outfile)
+    save_as_img(ascii_image, outfile)
+    return outfile
 
 
 @app.route('/')
@@ -37,7 +34,7 @@ def index():
     return render_template('index.html', **{
         'image': convert_image(config['DEFAULT_IMAGE_PATH']),
         'filename': config['DEFAULT_IMAGE_PATH'],
-    })
+        })
 
 
 @app.route('/generate', methods=['POST'])
@@ -49,10 +46,10 @@ def generate():
     if file1 and is_supported(file1.filename):
         path = os.path.join(config['UPLOAD_FOLDER'], secure_filename(file1.filename))
         file1.save(path)
-        ascii_image = convert_image(path)
+        converted_image = convert_image(path)
         if os.path.exists(path):
             os.remove(path)
-        return render_template('index.html', image=ascii_image, filename=file1.filename)
+        return render_template('index.html', image=converted_image, filename=file1.filename)
     else:
         flash(f"File must be one of: {', '.join(ALLOWED_EXTENSIONS)}", category='error')
         return redirect(url_for('index'))

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,7 @@
     <!--Image container-->
     <div class="mb-4 bg-light text-dark border rounded p-4 shadow">
         <div class="text-center">
-            <h1 style="font-family: monospace; font-weight: bold; white-space: pre; font-size: 0.25rem;" id="the_text">{{ image }}</h1>
+            <img src="{{ image }}" width=80% height=auto alt="converted image">
         </div>
     <!--Button group-->
         <div class="border border-dark rounded p-2">

--- a/web_config.py
+++ b/web_config.py
@@ -8,7 +8,7 @@ import os
 
 UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', 'webapp/uploads')
 TXT_FOLDER = os.environ.get('TXT_FOLDER', 'webapp')
-ASCII_IMAGE_FOLDER = os.environ.get('ASCII_IMAGE_FOLDER', 'webapp')
+ASCII_IMAGE_FOLDER = os.environ.get('ASCII_IMAGE_FOLDER', 'static')
 MAX_CONTENT_LENGTH = int(os.environ.get('MAX_CONTENT_LENGTH', f"{4 * 1024 * 1024}"))  # File max size set to 4MB
 KEY_FOLDER = os.environ.get('KEY_FOLDER', 'akey.txt')
 DEFAULT_IMAGE_PATH = os.environ.get('DEFAULT_IMAGE_PATH', 'example/ztm-logo.png')


### PR DESCRIPTION
This change makes the ascii image scalable with the window by displaying a .png rather than the text.

- index.html loads an img instead of text
-  web_config.py ASCII_IMAGE_FOLDER changed to 'static'
- app.py convert_image returns the converted png location
<img width="570" alt="Screenshot 2021-10-31 at 14 58 48" src="https://user-images.githubusercontent.com/87418591/139589764-c84d4f54-f0f9-4b53-9700-3457790201e1.png">

